### PR TITLE
fix bmfont output for Connect IQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ object_script.*
 bin
 FontBuilder.pro.user
 _build
+.DS_Store
+.qmake.stash

--- a/FontBuilder.pro
+++ b/FontBuilder.pro
@@ -73,8 +73,8 @@ SOURCES += src/main.cpp \
     src/layouters/gridlinelayouter.cpp \
     src/exporters/myguiexporter.cpp \
     src/exporters/bmfontexporter.cpp \
-    src/exporters/ageexporter.cpp 
-    
+    src/exporters/ageexporter.cpp
+
 
 HEADERS += src/fontbuilder.h \
     src/colorbutton.h \
@@ -118,8 +118,8 @@ HEADERS += src/fontbuilder.h \
     src/layouters/gridlinelayouter.h \
     src/exporters/myguiexporter.h \
     src/exporters/bmfontexporter.h \
-    src/exporters/ageexporter.h 
-    
+    src/exporters/ageexporter.h
+
 
 FORMS += src/fontbuilder.ui \
     src/fontselectframe.ui \
@@ -158,6 +158,7 @@ isEmpty(FREETYPE2CONFIG) {
         LIBS += -L/opt/local/lib
     # homebrew support
         INCLUDEPATH += /usr/local/include /usr/local/include/freetype2
+        LIBS += -L/usr/local/lib
     }
     win32 {
         INCLUDEPATH += ../include

--- a/src/abstractimagewriter.cpp
+++ b/src/abstractimagewriter.cpp
@@ -67,7 +67,7 @@ static void placeImage(QImage& dst,int x,int y,const QImage& src) {
 QImage AbstractImageWriter::buildImage() {
     QImage pixmap(layout()->width(),layout()->height(),QImage::Format_ARGB32);
 
-    pixmap.fill(0x00ffffff);
+    pixmap.fill(0xff000000);
 
 
     /*

--- a/src/exporters/bmfontexporter.cpp
+++ b/src/exporters/bmfontexporter.cpp
@@ -36,6 +36,10 @@ bool BMFontExporter::Export(QByteArray &out)
         + QString(" file=\"%1\"").arg(texFilename())
         .toUtf8()).append('\n');
 
+    out.append( QString("chars")
+        + QString(" count=%1").arg(symbols().length())
+        .toUtf8()).append('\n');
+
     foreach(const Symbol& c , symbols()) {
         out.append( QString("char")
             + QString(" id=%1").arg(c.id)

--- a/src/fontbuilder.cpp
+++ b/src/fontbuilder.cpp
@@ -231,7 +231,7 @@ void FontBuilder::setLayoutImage(const QImage& image) {
 
 void FontBuilder::onLayoutChanged() {
     QImage image (m_layout_data->width(),m_layout_data->height(),QImage::Format_ARGB32);
-    image.fill(0);
+    image.fill(0xff000000);
     {
         QPainter painter(&image);
         foreach (const LayoutChar& c,m_layout_data->placed()) {

--- a/src/fontdrawwidget.cpp
+++ b/src/fontdrawwidget.cpp
@@ -73,7 +73,7 @@ void FontDrawWidget::paintEvent(QPaintEvent *) {
         if (m_renderer_data->chars[c.symbol].locked)
             painter.setPen(QColor(255,0,0,255));
         else
-            painter.setPen(QColor(0,0,255,255));
+            painter.setPen(QColor(255,0,255,255));
         painter.drawRect((c.x)*m_scale,(c.y)*m_scale,(c.w)*m_scale-1,(c.h)*m_scale-1);
     }
 }

--- a/src/fontrenderer.cpp
+++ b/src/fontrenderer.cpp
@@ -199,7 +199,7 @@ bool FontRenderer::append_bitmap(uint symbol) {
     int w = bm->width;
     int h = bm->rows;
     QImage img(w,h,QImage::Format_ARGB32);
-    img.fill(0x00ffffff);
+    img.fill(0xff000000);
     const uchar* src = bm->buffer;
     //QColor bg = m_config->bgColor();
     //QColor fg = m_config->fgColor();
@@ -209,8 +209,12 @@ bool FontRenderer::append_bitmap(uint symbol) {
             for (int col=0;col<w;col++) {
                  {
                     uchar s = src[col];
-                    *dst = qRgba(0xff,0xff,0xff,
-                            s);
+                    // if (s == 0) {
+                    //     *dst = qRgba(0, 0, 0, 255);
+                    // } else {
+                    //     *dst = qRgba(0xff,0xff,0xff, s);
+                    // }
+                    *dst = qRgba(s, s, s, 255);
                 }
                 dst++;
             }

--- a/src/image/targawriter.cpp
+++ b/src/image/targawriter.cpp
@@ -185,7 +185,7 @@ QImage* TargaImageWriter::reload(QFile& file) {
     /// @todo endian !
     QImage* img = 0;
     img = new QImage(width,height,QImage::Format_ARGB32);
-    img->fill(0);
+    img->fill(0xff000000);
     uchar* data = reinterpret_cast<uchar*>(img->bits());
     if (bpp==32) {
         if (!rle) {


### PR DESCRIPTION
- Connect IQ requires a `chars count={}` line in the `.fnt` output
- Garmin anti-aliasing doesn't support PNG alpha channel - this PR instead fills the RGB channels appropriately